### PR TITLE
fix(lang en): correct capitalization of page title

### DIFF
--- a/src/translations/en.yaml
+++ b/src/translations/en.yaml
@@ -2,7 +2,7 @@
 # Copyright (c) 2022, Jari Hämäläinen, Carita Kiili and Julie Coiro
 page:
   # Translations affect the HTML page directly go here
-  title: Online inquiry tool
+  title: Online Inquiry Tool
 misc:
   # The name suggested when saving new char the first time.
   default-filename: chart


### PR DESCRIPTION
Changed page title to "Online Inquiry Tool" in English translation.