### PR TITLE
fix: always use selected locale for suggested filename (#14)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -101,8 +101,7 @@ const onChartNew = async () => {
 };
 
 const resetModel = () => {
-  const filename = t('misc.default-filename');
-  store.newModel(filename);
+  store.newModel();
 };
 
 const onChartSave = () => {

--- a/src/components/ModalChartSave.vue
+++ b/src/components/ModalChartSave.vue
@@ -31,9 +31,11 @@ const emit = defineEmits<{
 }>();
 
 const store = useStore();
-const {filename} = storeToRefs(store);
+const {filename: storeFilename} = storeToRefs(store);
 const {t} = useI18n();
 const tc = (s: string) => t(`component.modal-chart-save.${s}`);
+
+const filename = ref('');
 
 const modal = ref<InstanceType<typeof ModalBase>>();
 const {modalInterface, bind} = useModalBase(modal, {
@@ -43,10 +45,19 @@ const {modalInterface, bind} = useModalBase(modal, {
   ariaBtnClose: 'component.modal-chart-save.btn.close.aria-label',
 });
 
-defineExpose({...modalInterface});
+const show = () => {
+  filename.value =
+    storeFilename.value !== null
+      ? storeFilename.value
+      : t('misc.default-filename');
+  modalInterface.show();
+};
+
+defineExpose({...modalInterface, show});
 
 const onSaveAs = () => {
-  emit('chart-save-as', filename.value);
+  storeFilename.value = filename.value;
+  emit('chart-save-as', filename.value || '');
   modalInterface.hide();
 };
 </script>

--- a/src/stores/main.ts
+++ b/src/stores/main.ts
@@ -17,7 +17,8 @@ import {
 interface StoreState {
   data: Model;
   dirty: boolean;
-  filename: string;
+  // null = use default filename from translations
+  filename: string | null;
 }
 
 export const useStore = defineStore('main', {
@@ -25,11 +26,11 @@ export const useStore = defineStore('main', {
     return {
       data: getDefaultModel(),
       dirty: false,
-      filename: '',
+      filename: null,
     };
   },
   actions: {
-    newModel(filename: string) {
+    newModel(filename: string | null = null) {
       resetIds();
       this.$patch((state) => {
         state.data = getDefaultModel();


### PR DESCRIPTION
Suggested filename was set only when model was reset (app open and new
chart). Because of this the suggestion didn't update when locale was
changed by user.

Fixed by updating suggestion when save dialog is shown if filename has
not been set by user.