### PR TITLE
fix: correct language names in language selection dialog

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -64,7 +64,12 @@ const {languages} = useModalLanguages(
     .sort()
     .map((locale) => ({
       locale,
-      name: t(`language.${locale}`, {locale: 'en'}),
+      // Composition api of vue-i18n has only 1 and 3 argument
+      // versions. Use "plural" version with plural set to 1
+      // to get language names in locale 'en' (language names
+      // are special: 'en' translation has language names in
+      // their "translated state").
+      name: t(`language.${locale}`, 1, {locale: 'en'}),
     })),
 );
 


### PR DESCRIPTION
Language names were incorrect if the initial locale was something else than en. This happened because vue-i18n api changed a bit in newer version.

Fixed by using vue-i18n api correctly.

Closes: #47