### PR TITLE
fix: ensure perspectives have at least empty default arguments

### DIFF
--- a/src/stores/main.ts
+++ b/src/stores/main.ts
@@ -52,6 +52,15 @@ export const useStore = defineStore('main', {
         // Reset ids taking parsed data into account
         resetIds(data);
         this.$patch((state) => {
+          // Ensure that all perspectives' arguments lists have at least
+          // one default (empty) argument. Perspectives w/o any arguments
+          // are saved with empty argument table so parsed data may have
+          // empty arrays.
+          data.perspectives.forEach((p) => {
+            [p.argumentsFor, p.argumentsAgainst].forEach((args) => {
+              if (args.length === 0) args.push(getDefaultArgument());
+            });
+          });
           state.data = {...data};
           state.dirty = false;
           state.filename = filenameToChartname(filename);


### PR DESCRIPTION
Saved chart data has empty argument table for perspectives that don't have any argument data. This caused loaded charts to have missing default empty arguments which may look weird to the user.

Fixed by ensuring that there's always at least the default empty arguments in perspective after loading.

Closes: #49