### PR TITLE
fix: handle undefined arguments correctly when de-/serializing

### DIFF
--- a/src/print/print.mustache
+++ b/src/print/print.mustache
@@ -35,7 +35,7 @@
                     <tbody>
                     {{#arguments}}
                       <tr class="oit-arguments">
-                        <td class="oit-argument oit-argument-for oit-empty-{{for.empty}}">
+                        <td class="oit-argument oit-argument-for oit-empty-{{for.empty}} oit-undefined-{{for.undefined}}">
                           <div class="hi">
                             <strong>{{t.argument-for-items.argument}}</strong>
                             <span class="oit-argument-for-argument oit-text" data-text="{{for.argumentOrig}}">{{for.argument}}</span>
@@ -53,7 +53,7 @@
                             <span class="oit-argument-for-justification oit-text" data-text="{{for.justificationOrig}}">{{for.justification}}</span>
                           </div>
                         </td>
-                        <td class="oit-argument oit-argument-against oit-empty-{{against.empty}}">
+                        <td class="oit-argument oit-argument-against oit-empty-{{against.empty}} oit-undefined-{{against.undefined}}">
                           <div class="hi">
                             <strong>{{t.argument-against-items.argument}}</strong>
                             <span class="oit-argument-against-argument oit-text" data-text="{{against.argumentOrig}}">{{against.argument}}</span>

--- a/src/print/print.ts
+++ b/src/print/print.ts
@@ -16,7 +16,9 @@ import {
 // 1.1.0: added reliabilityOrig to PrintArgument to store Reliability value in
 //        data-text attribute of oit-argument-for-reliability and
 //        oit-argument-against-reliability elements.
-const docVersion = '1.1.0';
+// 1.1.1: Added oit-undefined-false and oit-undefined-true classes to arguments
+//        to mark if original document actually had argument (oit-undefined-false).
+const docVersion = '1.1.1';
 
 export interface PrintTranslations {
   [key: string]: PrintTranslations | string | (() => string);
@@ -24,6 +26,7 @@ export interface PrintTranslations {
 
 interface PrintArgument extends Omit<Argument, 'reliability'> {
   empty: boolean;
+  undefined: boolean;
   reliability: Reliability | null | string;
   reliabilityOrig: Reliability | '[not-set]';
   argumentOrig: string;
@@ -59,6 +62,7 @@ function argumentToPrintArgument(
   if (!a || argumentIsEmpty(a)) {
     return {
       empty: true,
+      undefined: !a,
       argument: '\xa0',
       id: '\xa0',
       justification: '\xa0',
@@ -72,6 +76,7 @@ function argumentToPrintArgument(
   }
   return {
     empty: false,
+    undefined: false,
     argument: a.argument.trim() || tEmpty,
     argumentOrig: a.argument,
     id: a.id.trim() || '\xa0',
@@ -97,13 +102,13 @@ function perpectiveToPrintPerspective(
     paf = argumentToPrintArgument(p.argumentsFor[i], tEmpty, tRel);
     paa = argumentToPrintArgument(p.argumentsAgainst[i], tEmpty, tRel);
     i++;
-    if (!paf.empty || !paa.empty) {
+    if (!paf.undefined || !paa.undefined) {
       args.push({
         for: paf,
         against: paa,
       });
     }
-  } while (!paf.empty || !paa.empty);
+  } while (!paf.undefined || !paa.undefined);
 
   return {
     id: p.id.trim() || '\xa0',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,6 +38,7 @@ class OitHtmlParserContext implements Partial<Handler> {
   private p: Perspective | null = null;
   private af: Argument | null = null; // for
   private aa: Argument | null = null; // against
+  private argEmpty = false; // is current argument empty one
   private readText = false;
   private text = '';
   private stack: HtmlStackEntry[] = [];
@@ -80,9 +81,14 @@ class OitHtmlParserContext implements Partial<Handler> {
     if (current.clazz.includes('oit-perspective-synthesis') && this.p) {
       this.p.synthesis = current.data.text || '';
     }
+    // doc version 1.1.1 added oit-undefined-true for arguments that
+    // did not exist on original document (are added to serialized
+    // form with oit-undefined-true to keep serialization simpler).
+    // oit-empty-true class indicated that the argument existed
+    // in original document, but was empty.
     if (
       current.clazz.includes('oit-argument') &&
-      !current.clazz.includes('oit-empty')
+      !current.clazz.includes('oit-undefined-true')
     ) {
       if (current.clazz.includes('oit-argument-for')) {
         this.af = getDefaultArgument(this.idStore);
@@ -90,25 +96,47 @@ class OitHtmlParserContext implements Partial<Handler> {
       if (current.clazz.includes('oit-argument-against')) {
         this.aa = getDefaultArgument(this.idStore);
       }
+      this.argEmpty = current.clazz.includes('oit-empty-true');
     }
-    if (current.clazz.includes('oit-argument-for-argument') && this.af) {
+    if (
+      current.clazz.includes('oit-argument-for-argument') &&
+      this.af &&
+      !this.argEmpty
+    ) {
       this.af.argument = current.data.text || '';
     }
-    if (current.clazz.includes('oit-argument-against-argument') && this.aa) {
+    if (
+      current.clazz.includes('oit-argument-against-argument') &&
+      this.aa &&
+      !this.argEmpty
+    ) {
       this.aa.argument = current.data.text || '';
     }
-    if (current.clazz.includes('oit-argument-for-source') && this.af) {
+    if (
+      current.clazz.includes('oit-argument-for-source') &&
+      this.af &&
+      !this.argEmpty
+    ) {
       this.af.source = current.data.text || '';
     }
-    if (current.clazz.includes('oit-argument-against-source') && this.aa) {
+    if (
+      current.clazz.includes('oit-argument-against-source') &&
+      this.aa &&
+      !this.argEmpty
+    ) {
       this.aa.source = current.data.text || '';
     }
-    if (current.clazz.includes('oit-argument-for-justification') && this.af) {
+    if (
+      current.clazz.includes('oit-argument-for-justification') &&
+      this.af &&
+      !this.argEmpty
+    ) {
       this.af.justification = current.data.text || '';
     }
     if (
       current.clazz.includes('oit-argument-against-justification') &&
-      this.aa
+      this.aa &&
+      !this.argEmpty
     ) {
       this.aa.justification = current.data.text || '';
     }
@@ -140,7 +168,11 @@ class OitHtmlParserContext implements Partial<Handler> {
       }
     }
 
-    if (current.clazz.includes('oit-argument-for-reliability') && this.af) {
+    if (
+      current.clazz.includes('oit-argument-for-reliability') &&
+      this.af &&
+      !this.argEmpty
+    ) {
       let val: string;
       if (current.data.text) {
         // doc version >= 1.1.0
@@ -151,7 +183,11 @@ class OitHtmlParserContext implements Partial<Handler> {
       }
       this.af.reliability = stringToReliability(val);
     }
-    if (current.clazz.includes('oit-argument-against-reliability') && this.aa) {
+    if (
+      current.clazz.includes('oit-argument-against-reliability') &&
+      this.aa &&
+      !this.argEmpty
+    ) {
       let val: string;
       if (current.data.text) {
         // doc version >= 1.1.0


### PR DESCRIPTION
Serialization code marked undefined arguments as empty so they appeared as new empty arguments after opening saved chart.

Fixed by adding oit-undefined-true marker class to undefined arguments and filtering them on open.

Closes: #52