### PR TITLE
fix: correct id reset on chart deserialization

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -87,17 +87,20 @@ export function resetIds(data?: Model) {
   idStore.perspectiveId = 0;
   idStore.argumentId = 0;
   if (!data) return;
+
+  // idStore has the next available id so take that into account
+  // when checking existing ids (use `>=` and `+ 1`)
   data.perspectives.forEach((p) => {
     try {
       const n = getIdNumber(p.id);
-      if (n > idStore.perspectiveId) idStore.perspectiveId = n;
+      if (n >= idStore.perspectiveId) idStore.perspectiveId = n + 1;
     } catch (_) {
       // Ignore
     }
     p.argumentsFor.forEach((r) => {
       try {
         const n = getIdNumber(r.id);
-        if (n > idStore.argumentId) idStore.argumentId = n;
+        if (n >= idStore.argumentId) idStore.argumentId = n + 1;
       } catch (_) {
         // Ignore
       }
@@ -105,7 +108,7 @@ export function resetIds(data?: Model) {
     p.argumentsAgainst.forEach((r) => {
       try {
         const n = getIdNumber(r.id);
-        if (n > idStore.argumentId) idStore.argumentId = n;
+        if (n >= idStore.argumentId) idStore.argumentId = n + 1;
       } catch (_) {
         // Ignore
       }


### PR DESCRIPTION
Id reset set next available perspective / argument id to last used one.

Fixed by setting them to next available ones.

Closes: #53