### PR TITLE
Switch to sortablejs-vue3 from vuedraggable + drag improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,9 +44,10 @@
     "mustache": "4.2.0",
     "pinia": "2.1.7",
     "rfdc": "1.3.0",
+    "sortablejs": "1.15.1",
+    "sortablejs-vue3": "1.2.11",
     "vue": "3.3.9",
-    "vue-i18n": "9.8.0",
-    "vuedraggable": "4.1.0"
+    "vue-i18n": "9.8.0"
   },
   "devDependencies": {
     "@commitlint/cli": "18.4.3",
@@ -63,6 +64,7 @@
     "@types/markdown-it": "13.0.7",
     "@types/mustache": "4.2.5",
     "@types/node": "20.10.1",
+    "@types/sortablejs": "1.15.7",
     "@types/yargs": "17.0.32",
     "@typescript-eslint/eslint-plugin": "6.13.1",
     "@typescript-eslint/parser": "6.13.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,15 +44,18 @@ dependencies:
   rfdc:
     specifier: 1.3.0
     version: 1.3.0
+  sortablejs:
+    specifier: 1.15.1
+    version: 1.15.1
+  sortablejs-vue3:
+    specifier: 1.2.11
+    version: 1.2.11(sortablejs@1.15.1)(vue@3.3.9)
   vue:
     specifier: 3.3.9
     version: 3.3.9(typescript@5.3.2)
   vue-i18n:
     specifier: 9.8.0
     version: 9.8.0(vue@3.3.9)
-  vuedraggable:
-    specifier: 4.1.0
-    version: 4.1.0(vue@3.3.9)
 
 devDependencies:
   '@commitlint/cli':
@@ -97,6 +100,9 @@ devDependencies:
   '@types/node':
     specifier: 20.10.1
     version: 20.10.1
+  '@types/sortablejs':
+    specifier: 1.15.7
+    version: 1.15.7
   '@types/yargs':
     specifier: 17.0.32
     version: 17.0.32
@@ -1301,6 +1307,10 @@ packages:
 
   /@types/semver@7.5.0:
     resolution: {integrity: sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==}
+    dev: true
+
+  /@types/sortablejs@1.15.7:
+    resolution: {integrity: sha512-PvgWCx1Lbgm88FdQ6S7OGvLIjWS66mudKPlfdrWil0TjsO5zmoZmzoKiiwRShs1dwPgrlkr0N4ewuy0/+QUXYQ==}
     dev: true
 
   /@types/yargs-parser@21.0.0:
@@ -4826,8 +4836,18 @@ packages:
     engines: {node: '>=14.16'}
     dev: true
 
-  /sortablejs@1.14.0:
-    resolution: {integrity: sha512-pBXvQCs5/33fdN1/39pPL0NZF20LeRbLQ5jtnheIPN9JQAaufGjKdWduZn4U7wCtVuzKhmRkI0DFYHYRbB2H1w==}
+  /sortablejs-vue3@1.2.11(sortablejs@1.15.1)(vue@3.3.9):
+    resolution: {integrity: sha512-oKOA6N7yu2ktmqYXPHlPTQWbe9G4v16mn5ewogb+Ybc9Bk1Y+MIURrpbgedEv7f9TS5Bptvh81HGjazh5FEyJw==}
+    peerDependencies:
+      sortablejs: ^1.15.0
+      vue: ^3.2.25
+    dependencies:
+      sortablejs: 1.15.1
+      vue: 3.3.9(typescript@5.3.2)
+    dev: false
+
+  /sortablejs@1.15.1:
+    resolution: {integrity: sha512-P5Cjvb0UG1ZVNiDPj/n4V+DinttXG6K8n7vM/HQf0C25K3YKQTQY6fsr/sEGsJGpQ9exmPxluHxKBc0mLKU1lQ==}
     dev: false
 
   /source-map-js@1.0.2:
@@ -5414,15 +5434,6 @@ packages:
       '@vue/server-renderer': 3.3.9(vue@3.3.9)
       '@vue/shared': 3.3.9
       typescript: 5.3.2
-
-  /vuedraggable@4.1.0(vue@3.3.9):
-    resolution: {integrity: sha512-FU5HCWBmsf20GpP3eudURW3WdWTKIbEIQxh9/8GE806hydR9qZqRRxRE3RjqX7PkuLuMQG/A7n3cfj9rCEchww==}
-    peerDependencies:
-      vue: ^3.0.1
-    dependencies:
-      sortablejs: 1.14.0
-      vue: 3.3.9(typescript@5.3.2)
-    dev: false
 
   /wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}

--- a/src/components/ArgumentEditor.vue
+++ b/src/components/ArgumentEditor.vue
@@ -1,5 +1,7 @@
 <template lang="pug">
-section.argument-editor
+section.argument-editor(
+  :data-argument-id='argument.id'
+)
   .d-flex
     textarea.form-control.mb-1(
       v-model='argument.argument'

--- a/src/components/InquiryEditor.vue
+++ b/src/components/InquiryEditor.vue
@@ -68,6 +68,7 @@ const store = useStore();
 const {data, dirty} = storeToRefs(store);
 
 const sortableOptions = ref<SortableOptions>({
+  animation: 300,
   group: 'perspectives',
   handle: '.drag-handle',
 });

--- a/src/components/PerspectiveEditor.vue
+++ b/src/components/PerspectiveEditor.vue
@@ -112,6 +112,7 @@ const emit = defineEmits<{
 }>();
 
 const sortableOptions = ref<SortableOptions>({
+  animation: 300,
   group: 'arguments',
   handle: '.drag-handle',
 });

--- a/src/model.ts
+++ b/src/model.ts
@@ -17,6 +17,10 @@ export interface Argument {
 
 export type ArgumentKind = 'for' | 'against';
 
+export function isArgumentKind(o: any): o is ArgumentKind {
+  return o === 'for' || o === 'against';
+}
+
 export interface Perspective {
   name: string;
   questions: string;

--- a/src/stores/main.ts
+++ b/src/stores/main.ts
@@ -14,6 +14,15 @@ import {
   IdStore,
 } from '../model';
 
+export interface MoveArgumentOpts {
+  fromPrsId: string;
+  fromArgKind: ArgumentKind;
+  fromIndex: number;
+  toPrsId: string;
+  toArgKind: ArgumentKind;
+  toIndex: number;
+}
+
 interface StoreState {
   data: Model;
   dirty: boolean;
@@ -84,6 +93,18 @@ export const useStore = defineStore('main', {
         state.dirty = true;
       });
     },
+    movePerspective(fromIndex: number, toIndex: number) {
+      this.$patch((state) => {
+        const prs = state.data.perspectives.splice(fromIndex, 1)[0];
+        state.data.perspectives.splice(toIndex, 0, prs);
+
+        // Set new id for moved perspective so that html gets reactively updated.
+        const tmp = getDefaultPerspective();
+        prs.id = tmp.id;
+
+        state.dirty = true;
+      });
+    },
     addArgument(target: Perspective, kind: ArgumentKind) {
       this.$patch((state) => {
         const t = state.data.perspectives.find((p) => p.id === target.id);
@@ -107,6 +128,28 @@ export const useStore = defineStore('main', {
         state.dirty = true;
       });
     },
+    moveArgument(opts: MoveArgumentOpts) {
+      this.$patch((state) => {
+        const from = getArgumentList(
+          state.data,
+          opts.fromPrsId,
+          opts.fromArgKind,
+        );
+        const to = getArgumentList(state.data, opts.toPrsId, opts.toArgKind);
+        if (!from || !to) return;
+
+        const arg = from.splice(opts.fromIndex, 1)[0];
+        to.splice(opts.toIndex, 0, arg);
+
+        // Set new id for moved argument so that html gets reactively updated
+        // (we remove dragged element after drag finishes because otherwise
+        // dragging from one list to another would cause duplicates).
+        const tmp = getDefaultArgument();
+        arg.id = tmp.id;
+
+        state.dirty = true;
+      });
+    },
     updateClaim(claim: string) {
       this.$patch((state) => {
         state.data.claim = claim;
@@ -123,3 +166,13 @@ export const useStore = defineStore('main', {
 });
 
 export type MainStore = ReturnType<typeof useStore>;
+
+function getArgumentList(
+  model: Model,
+  prsId: string,
+  argKind: ArgumentKind,
+): Argument[] | undefined {
+  const prs = model.perspectives.find((p) => p.id === prsId);
+  if (!prs) return undefined;
+  return argKind === 'for' ? prs.argumentsFor : prs.argumentsAgainst;
+}


### PR DESCRIPTION
Switch to sortablejs-vue3 from vuedraggable because vuedraggable is unmaintained.

Also, add animation to dragging to make it visually easier to see what's going on.