### PR TITLE
fix: place sortable fallback element on body

### DIFF
--- a/src/components/InquiryEditor.vue
+++ b/src/components/InquiryEditor.vue
@@ -71,6 +71,13 @@ const sortableOptions = ref<SortableOptions>({
   animation: 300,
   group: 'perspectives',
   handle: '.drag-handle',
+  // Sortable uses its "fallback" on mobile and by default it
+  // appends "fallback element" to the list causing `:empty`
+  // css selector to fail during drag. Place "fallback element"
+  // on body instead. NOTE: Not exactly necessary on perspective
+  // list as it cannot become empty while dragging but using
+  // this anyway to keep behavior similar to argument lists.
+  fallbackOnBody: true,
 });
 
 const mdlArgEditor = ref<InstanceType<typeof ModalArgumentEditor>>();

--- a/src/components/PerspectiveEditor.vue
+++ b/src/components/PerspectiveEditor.vue
@@ -115,6 +115,11 @@ const sortableOptions = ref<SortableOptions>({
   animation: 300,
   group: 'arguments',
   handle: '.drag-handle',
+  // Sortable uses its "fallback" on mobile and by default it
+  // appends "fallback element" to the list causing `:empty`
+  // css selector to fail during drag. Place "fallback element"
+  // on body instead.
+  fallbackOnBody: true,
 });
 
 const onSortableEnd = (event: SortableEvent) => {


### PR DESCRIPTION
Sortable uses its "fallback" on mobile and by default it appends "fallback element" to the list causing `:empty` css selector to fail during drag.

Fixed by placing "fallback element" on body instead.

Closes: #64