### PR TITLE
fix: make titled notes title responsive

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -227,4 +227,20 @@ $primary: #6c3d71;
     height: 30px;
   }
 }
+
+.titled-notes .title {
+  min-width: 15ch;
+}
+
+@include media-breakpoint-up(md) {
+  .titled-notes .title {
+    min-width: 30ch;
+  }
+}
+
+@include media-breakpoint-up(lg) {
+  .titled-notes .title {
+    min-width: 40ch;
+  }
+}
 </style>

--- a/src/components/TitledNotes.vue
+++ b/src/components/TitledNotes.vue
@@ -37,9 +37,6 @@ const onInput = (evt: Event) => {
 
 <style lang="scss">
 .titled-notes {
-  .title {
-    min-width: 40ch;
-  }
   .notes {
     resize: none;
     &.notes-resizable {


### PR DESCRIPTION
So that at least that component doesn't break responsiveness (while many others still do).

Related to: #67